### PR TITLE
トップ画面のサイドメニューのUIを作成した

### DIFF
--- a/Child/Child.xcodeproj/project.pbxproj
+++ b/Child/Child.xcodeproj/project.pbxproj
@@ -105,7 +105,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FA5585B82E13B04400CF231E /* Build configuration list for PBXNativeTarget "Child" */;
 			buildPhases = (
-				FA609A3F2E19795E00C9DC9C /* Run SwiftLint */,
 				FA5585902E13B04200CF231E /* Sources */,
 				FA5585912E13B04200CF231E /* Frameworks */,
 				FA5585922E13B04200CF231E /* Resources */,
@@ -119,8 +118,6 @@
 				FA5585DC2E13B6F700CF231E /* Preview Content */,
 			);
 			name = Child;
-			packageProductDependencies = (
-			);
 			productName = Child;
 			productReference = FA5585942E13B04200CF231E /* Child.app */;
 			productType = "com.apple.product-type.application";
@@ -142,8 +139,6 @@
 				FA5585A72E13B04400CF231E /* ChildTests */,
 			);
 			name = ChildTests;
-			packageProductDependencies = (
-			);
 			productName = ChildTests;
 			productReference = FA5585A42E13B04400CF231E /* ChildTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -165,8 +160,6 @@
 				FA5585B12E13B04400CF231E /* ChildUITests */,
 			);
 			name = ChildUITests;
-			packageProductDependencies = (
-			);
 			productName = ChildUITests;
 			productReference = FA5585AE2E13B04400CF231E /* ChildUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -238,28 +231,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		FA609A3F2E19795E00C9DC9C /* Run SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftLint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint --fix\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		FA5585902E13B04200CF231E /* Sources */ = {

--- a/Child/Child/View/ContentView.swift
+++ b/Child/Child/View/ContentView.swift
@@ -10,12 +10,13 @@ import SwiftUI
 struct ContentView: View {
 
   @StateObject private var ViewModel: ContentViewModel = ContentViewModel()
-  private let TextEditorLeadingPaddingRatio: CGFloat = 0.024
+  private let TextEditorSidePaddingRatio: CGFloat = 0.024
 
     var body: some View {
       GeometryReader { geometry in
         TextEditor(text: $ViewModel.textContent)
-          .padding(.leading, geometry.size.width * TextEditorLeadingPaddingRatio)
+          .padding(.leading, geometry.size.width * TextEditorSidePaddingRatio)
+          .padding(.trailing, geometry.size.width * TextEditorSidePaddingRatio)
       }
     }
 }

--- a/Child/Child/View/TitleView.swift
+++ b/Child/Child/View/TitleView.swift
@@ -12,14 +12,15 @@ struct TitleView: View {
   @StateObject private var viewModel: TitleViewModel = TitleViewModel()
   // iPhone16Proの画面のHeight874（CSSピクセル）を基準に算出
   private let titleTextSizeRatio: CGFloat = 0.074
-  private let TextFieldLeadingPaddingRatio: CGFloat = 0.024
+  private let TextFieldSidePaddingRatio: CGFloat = 0.024
 
   var body: some View {
     GeometryReader { geometry in
 
       TextField("Title", text: $viewModel.title)
         .font(.system(size: geometry.size.width * titleTextSizeRatio))
-        .padding(.leading, geometry.size.width * TextFieldLeadingPaddingRatio)
+        .padding(.leading, geometry.size.width * TextFieldSidePaddingRatio)
+        .padding(.trailing, geometry.size.width * TextFieldSidePaddingRatio)
     }
   }
 }

--- a/Child/Child/View/Top/SideMenu/SideMenuView.swift
+++ b/Child/Child/View/Top/SideMenu/SideMenuView.swift
@@ -8,11 +8,97 @@
 import SwiftUI
 
 struct SideMenuView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  
+  // MARK: - Properties
+  
+  @StateObject var viewModel: SideMenuViewModel = SideMenuViewModel()
+  private let maxWidth = UIScreen.main.bounds.width
+  
+  // Iphone16Pro(Height: 874px)を基準に各レートを算出
+  // 例　memoRowsHeightRatio → 38 % 874 = 0.043478.....
+  private let memoRowsHeightRatio: CGFloat = 0.0434
+  private let chevronRightIconHeightRatio: CGFloat = 0.0228
+  private let moreTextHeightRatio: CGFloat = 0.0228
+  private let gearshapeIconHeightRatio: CGFloat = 0.040
+  private let gearshapeIconTrailingPaddingRatio = 0.017
+  private let moreSectionFotterHeightRatio: CGFloat = 0.068
+  private let settingsSectionSpaceRatio: CGFloat = 0.0228
+  
+  
+  // MARK: - Body
+  
+  var body: some View {
+    ZStack {
+      GeometryReader { geometry in
+      Color.black
+        .edgesIgnoringSafeArea(.all)
+        .opacity(0.4)
+      ZStack {
+        
+        let fullHeight = geometry.size.height + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom
+        
+          List() {
+            
+            Section {
+              ForEach(viewModel.sideMenuMemoLists, id: \.self) { memo in
+                Text(memo)
+                  .frame(height: fullHeight * memoRowsHeightRatio)
+              }
+            }
+            
+            Section {
+              HStack {
+                Spacer()
+                HStack(spacing: 4) {
+                  Text("more")
+                    .font(.system(size: fullHeight * moreTextHeightRatio))
+                  Image(systemName: "chevron.right")
+                }
+                .font(.body)
+                .font(.system(size: fullHeight * chevronRightIconHeightRatio))
+                .foregroundStyle(.gray)
+              }
+              .listRowBackground(Color.clear)
+              .listRowSeparator(.hidden)
+            } footer: {
+              
+              // フッターを使って余白を作成
+              Spacer()
+                .frame(height: fullHeight * moreSectionFotterHeightRatio)
+            }
+            
+            Section {
+              VStack(spacing: fullHeight * settingsSectionSpaceRatio) {
+                Divider()
+                  .frame(height: 1.5)
+                  .background(Color.gray.opacity(0.4))
+                  .shadow(color: Color.black.opacity(0.4),
+                          radius: 4, x: 0, y: -2)
+                
+                HStack {
+                  Spacer()
+                  Image(systemName: "gearshape")
+                    .font(.system(size: fullHeight * gearshapeIconHeightRatio))
+                    .foregroundStyle(.gray)
+                    .padding(.trailing, fullHeight * gearshapeIconTrailingPaddingRatio)
+                }
+              }
+              .listRowInsets(EdgeInsets())
+              .listRowBackground(Color.clear)
+              .listRowSeparator(.hidden)
+            }
+          }
+          .scrollDisabled(true)
+          .listStyle(.grouped)
+          .frame(maxHeight: geometry.size.height)
+        }
+        .padding(.trailing, maxWidth/4)
+        .offset(x: 0)
+      }
     }
+  }
 }
 
 #Preview {
-    SideMenuView()
+  SideMenuView()
 }

--- a/Child/Child/View/TopView.swift
+++ b/Child/Child/View/TopView.swift
@@ -11,41 +11,46 @@ struct TopView: View {
 
 // MARK: Properties
 // iPhone16Proの画面のHeight874（CSSピクセル）を基準に算出
-
   private let titleHeightRatio: CGFloat = 0.11
-  private let contentHeightRatio: CGFloat = 0.74
-  private let spacerHeightRatio: CGFloat = 0.023
+  private let contentHeightRatio: CGFloat = 0.66
+  private let sideMenuIconBottomSpacerHeightRatio: CGFloat = 0.06
+  private let contentViewBottomSpacerHeightRatio: CGFloat = 0.023
   private let adBannerHeight: CGFloat = 50
+  private let sideMenuIconSidePaddingRatio: CGFloat = 0.024
+  private let sideMenuIconSizeRatio: CGFloat = 0.036
 
 // MARK: Body
 
   var body: some View {
     GeometryReader { geometry in
-
-      VStack(spacing: 0) {
-        HStack {
-          Spacer()
-
-          Image(systemName: "line.3.horizontal")
-            .font(.system(size: 32, weight: .bold))
-            .padding(.trailing, 15)
-        }
-        .font(.system(size: 32, weight: .bold))
-
-        Spacer().frame(height: geometry.size.height * spacerHeightRatio)
-
-        TitleView()
-          .frame(height: geometry.size.height * titleHeightRatio)
-
-        ContentView()
-          .frame(height: geometry.size.height * contentHeightRatio)
+      
+      ZStack {
+        VStack(spacing: 0) {
+          HStack {
+            Image(systemName: "line.3.horizontal")
+              .font(.system(size: geometry.size.height * sideMenuIconSizeRatio , weight: .bold))
+              .padding(.leading, geometry.size.width * sideMenuIconSidePaddingRatio)
+              .padding(.trailing, geometry.size.width * sideMenuIconSidePaddingRatio)
+            //ハンバーガーメニューアイコンとTitleViewの余白を調整する
+            Spacer()
+          }
           
-
-        Spacer().frame(height: geometry.size.height * spacerHeightRatio)
-
-        Color.yellow
-          .frame(height: adBannerHeight)
-          .overlay(Text("Ad Banner"))
+          Spacer().frame(height: geometry.size.height * sideMenuIconBottomSpacerHeightRatio)
+          
+          TitleView()
+            .frame(height: geometry.size.height * titleHeightRatio)
+          
+          ContentView()
+            .frame(height: geometry.size.height * contentHeightRatio)
+          
+          
+          Spacer().frame(height: geometry.size.height * contentViewBottomSpacerHeightRatio)
+          
+          Color.yellow
+            .frame(height: adBannerHeight)
+            .overlay(Text("Ad Banner"))
+        }
+        SideMenuView()
       }
     }
   }

--- a/Child/Child/ViewModel/ContentViewModel.swift
+++ b/Child/Child/ViewModel/ContentViewModel.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 class ContentViewModel: ObservableObject {
+  
+  // MARK: - Properties
 
   @Published var textContent: String = ""
 }

--- a/Child/Child/ViewModel/SideMenuViewModel.swift
+++ b/Child/Child/ViewModel/SideMenuViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  SideMenuViewModel.swift
+//  Child
+//
+//  Created by 川島真之 on 2025/07/09.
+//
+
+import Foundation
+
+class SideMenuViewModel: ObservableObject {
+  
+  // MARK: - Properties
+  
+  @Published  var sideMenuMemoLists = ["メモ１", "メモ２", "メモ3", "メモ4", "メモ5", "メモ6", "メモ7", "メモ8"]
+}

--- a/Child/Child/ViewModel/TitleViewModel.swift
+++ b/Child/Child/ViewModel/TitleViewModel.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 class TitleViewModel: ObservableObject {
+  
+  // MARK: - Properties
 
   @Published var title: String = ""
 }


### PR DESCRIPTION
## issue
close #14 
## やったこと
- サイドメニューのUI作成
- トップ画面のサイドメニューのアイコンの表示位置を左端に変更
- 他UI微調整

## トップ画面UI
- サイドメニュー表示
![Simulator Screenshot - iPhone 16 Pro - 2025-07-09 at 17 33 12](https://github.com/user-attachments/assets/019c8b30-5707-4c7f-bb26-ad7d70e8806e)

- 非表示
![Simulator Screenshot - iPhone 16 Pro - 2025-07-09 at 17 33 52](https://github.com/user-attachments/assets/3b4b9241-bf4c-4b85-bec2-570d09cf6652)


## やっていないこと
- サイドメニューの表示と非常時処理の実装

