### PR TITLE
メモ一覧画面に関する処理を作成した。

### DIFF
--- a/Child/Child/View/MemoList/MemoListView.swift
+++ b/Child/Child/View/MemoList/MemoListView.swift
@@ -25,9 +25,11 @@ struct MemoListView: View {
       
       List {
         Section {
-          ForEach(viewModel.sideMenuMemoLists, id: \.self) { memo in
+          ForEach(viewModel.getTitlesFromAllMemoLists(), id: \.self) { memo in
             Text(memo)
               .frame(height: fullHeight * memoRowsHeightRatio)
+              .lineLimit(1)
+              .truncationMode(.tail)
           }
         }
       }

--- a/Child/Child/View/Top/SideMenu/SideMenuView.swift
+++ b/Child/Child/View/Top/SideMenu/SideMenuView.swift
@@ -15,6 +15,7 @@ struct SideMenuView: View {
   
   @Binding var isOpen: Bool
   
+  
   private let maxWidth = UIScreen.main.bounds.width
   
   // Iphone16Pro(Height: 874px)を基準に各レートを算出
@@ -57,22 +58,29 @@ struct SideMenuView: View {
               }
               
               Section {
-                NavigationLink(destination: MemoListView()) {
-                  HStack(spacing: 4) {
-                    Spacer()
-                    Text("more")
-                      .font(.system(size: fullHeight * moreTextHeightRatio))
-                  }
-                  .foregroundStyle(.gray)
+                NavigationLink(
+                    destination: MemoListView()
+                        .onAppear {
+                            // 画面遷移のアニメーション時間を考慮して遅延
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                isOpen = false
+                            }
+                        }
+                ) {
+                    HStack(spacing: 4) {
+                        Spacer()
+                        Text("more")
+                            .font(.system(size: fullHeight * moreTextHeightRatio))
+                    }
+                    .foregroundStyle(.gray)
                 }
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
               } footer: {
-                
-                // フッターを使って余白を作成
                 Spacer()
                   .frame(height: fullHeight * moreSectionFotterHeightRatio)
               }
+
               
               Section {
                 VStack(spacing: fullHeight * settingsSectionSpaceRatio) {

--- a/Child/Child/ViewModel/MemoList/MemoListViewModel.swift
+++ b/Child/Child/ViewModel/MemoList/MemoListViewModel.swift
@@ -6,8 +6,31 @@
 //
 
 import Foundation
+import RealmSwift
 
 class MemoListViewModel: ObservableObject {
   
-  @Published  var sideMenuMemoLists = (1...20).map { "メモ\($0)" }
+  // MARK: - Properties
+  
+  @Published  var memoLists: Results<UserMemo>
+  
+  let realm: Realm
+  
+  // MARK: - Init
+  
+  init() {
+    self.realm = try! Realm()
+    memoLists = realm.objects(UserMemo.self).sorted(byKeyPath: "createdAt", ascending: false)
+  }
+  
+  // MARK: - Methods
+  
+  func getTitlesFromAllMemoLists() -> [String] {
+    // 実際のメモからタイトルを取得し、配列に変換
+    var titles = Array(memoLists.map { userMemo in
+      return userMemo.title.isEmpty ? "タイトル未設定" : userMemo.title
+    })
+    return titles
+  }
+
 }


### PR DESCRIPTION
## issue
close #30 
## やったこと
- メモ一覧画面に現在保存されている全てのメモが表示されるようにした。
- メモ一覧画面へ遷移時にサイドメニューが閉じるようにした。

## メモ一覧画面UI
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-17 at 14 53 44" src="https://github.com/user-attachments/assets/f2c7facd-7ff7-4350-b375-db7f9936d517" />

