### PR TITLE
メモ一覧画面のリスト押下時処理を作成した

### DIFF
--- a/Child/Child/View/MemoList/MemoListView.swift
+++ b/Child/Child/View/MemoList/MemoListView.swift
@@ -12,6 +12,7 @@ struct MemoListView: View {
   // MARK: - Properties
   
   @StateObject var viewModel: MemoListViewModel = MemoListViewModel()
+  @Environment(\.dismiss) private var dismiss
   
   private let memoRowsHeightRatio: CGFloat = 0.0434
   
@@ -25,15 +26,29 @@ struct MemoListView: View {
       
       List {
         Section {
-          ForEach(viewModel.getTitlesFromAllMemoLists(), id: \.self) { memo in
-            Text(memo)
-              .frame(height: fullHeight * memoRowsHeightRatio)
-              .lineLimit(1)
-              .truncationMode(.tail)
+          ForEach(viewModel.getDisplayItems()) { item in
+            HStack {
+              Text(item.displayTitle)
+                .frame(height: fullHeight * memoRowsHeightRatio)
+                .lineLimit(1)
+                .truncationMode(.tail)
+              
+              Spacer()
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+              handleMemoTap(item)
+            }
           }
         }
       }
     }
+  }
+  
+  // MARK: - Methods
+  private func handleMemoTap(_ item: UserMemoListItem) {
+    viewModel.selectMemo(item)
+    dismiss()
   }
 }
 

--- a/Child/Child/ViewModel/MemoList/MemoListViewModel.swift
+++ b/Child/Child/ViewModel/MemoList/MemoListViewModel.swift
@@ -7,20 +7,20 @@
 
 import Foundation
 import RealmSwift
+import Combine
 
 class MemoListViewModel: ObservableObject {
   
   // MARK: - Properties
   
   @Published  var memoLists: Results<UserMemo>
-  
   let realm: Realm
-  
   // MARK: - Init
   
   init() {
     self.realm = try! Realm()
     memoLists = realm.objects(UserMemo.self).sorted(byKeyPath: "createdAt", ascending: false)
+    
   }
   
   // MARK: - Methods
@@ -31,6 +31,21 @@ class MemoListViewModel: ObservableObject {
       return userMemo.title.isEmpty ? "タイトル未設定" : userMemo.title
     })
     return titles
+  }
+  
+  func getDisplayItems() -> [UserMemoListItem] {
+    var items: [UserMemoListItem] = []
+    
+    for userMemo in self.memoLists {
+      items.append(UserMemoListItem(userMemo: userMemo))
+    }
+    return items
+  }
+  
+  func selectMemo(_ item: UserMemoListItem) {
+    guard let userMemo = item.userMemo else { return }
+    CurrentUserMemoViewModel.shared.upDate(userMemo: userMemo)
+    print(CurrentUserMemoViewModel.shared.currentUserMemo)
   }
 
 }


### PR DESCRIPTION
## issue
close #36 
## やったこと
- メモ一覧画面のリストをタップ可能にした
- メモ一覧画面のリストをタップした時にメモ一覧画面を閉じ、トップ画面が表示されるようにした
- トップ画面が表示された時に、タップしたリストに対応した内容が表示されるようにした。
## やっていないこと
タップ時のリストのアニメーション
→現在の状態では、リストをタップしてもリスト自体には何の変化もないのでアニメーションをつけてタップされたことがユーザーに伝わるようにする。サイドメニューも同様な状況なので対応したい。
