### PR TITLE
トップ画面に新規メモ作成ボタンを配置し、押下時処理を作成した

### DIFF
--- a/Child/Child/View/Top/TopView.swift
+++ b/Child/Child/View/Top/TopView.swift
@@ -47,7 +47,7 @@ struct TopView: View {
               
               //新規メモ作成ボタン
               Button(action: {
-                //ボタン押下時処理
+                viewModel.upDateCurrentUserMemo()
               }) {
                 Image(systemName: "pencil.circle.fill")
                   .font(.system(size: geometry.size.height * iconSizeRatio , weight: .bold))

--- a/Child/Child/View/Top/TopView.swift
+++ b/Child/Child/View/Top/TopView.swift
@@ -19,8 +19,8 @@ struct TopView: View {
   private let sideMenuIconBottomSpacerHeightRatio: CGFloat = 0.06
   private let contentViewBottomSpacerHeightRatio: CGFloat = 0.023
   private let adBannerHeight: CGFloat = 50
-  private let sideMenuIconSidePaddingRatio: CGFloat = 0.024
-  private let sideMenuIconSizeRatio: CGFloat = 0.036
+  private let iconSidePaddingRatio: CGFloat = 0.024
+  private let iconSizeRatio: CGFloat = 0.036
   
   // MARK: Body
   
@@ -38,12 +38,22 @@ struct TopView: View {
                 }
               }) {
                 Image(systemName: "line.3.horizontal")
-                  .font(.system(size: geometry.size.height * sideMenuIconSizeRatio , weight: .bold))
+                  .font(.system(size: geometry.size.height * iconSizeRatio , weight: .bold))
                   .foregroundStyle(Color.black)
-                  .padding(.leading, geometry.size.width * sideMenuIconSidePaddingRatio)
-                  .padding(.trailing, geometry.size.width * sideMenuIconSidePaddingRatio)
+                  .padding(.leading, geometry.size.width * iconSidePaddingRatio)
               }
+              
               Spacer()
+              
+              //新規メモ作成ボタン
+              Button(action: {
+                //ボタン押下時処理
+              }) {
+                Image(systemName: "pencil.circle.fill")
+                  .font(.system(size: geometry.size.height * iconSizeRatio , weight: .bold))
+                  .foregroundStyle(Color.black)
+                  .padding(.trailing, geometry.size.width * iconSidePaddingRatio)
+              }
             }
             
             Spacer().frame(height: geometry.size.height * sideMenuIconBottomSpacerHeightRatio)

--- a/Child/Child/ViewModel/CurrentUserMemoViewModel.swift
+++ b/Child/Child/ViewModel/CurrentUserMemoViewModel.swift
@@ -13,7 +13,7 @@ final class CurrentUserMemoViewModel: ObservableObject {
   // MARK: - Properties
   // シングルトンとして定義
   static let shared: CurrentUserMemoViewModel = .init()
-  @Published var currentUserMemo: UserMemo
+  @Published  var currentUserMemo: UserMemo
   
   // MARK: - Init
   
@@ -26,5 +26,4 @@ final class CurrentUserMemoViewModel: ObservableObject {
   func upDate(userMemo: UserMemo) {
     self.currentUserMemo = userMemo
   }
-  
 }

--- a/Child/Child/ViewModel/Top/TopViewModel.swift
+++ b/Child/Child/ViewModel/Top/TopViewModel.swift
@@ -6,10 +6,31 @@
 //
 
 import Foundation
+import Combine
 
 class TopViewModel: ObservableObject {
   
   // MARK: - Properties
   
   @Published var isSideMenuOpen: Bool = false
+  private var currentUserMemoViewModel: CurrentUserMemoViewModel
+  private var cancellable: AnyCancellable?
+  
+  // MARK: - Init
+  
+  init(currentUserMemoViewModel: CurrentUserMemoViewModel = .shared) {
+    self.currentUserMemoViewModel = currentUserMemoViewModel
+
+    // currentUserMemo の変化を監視
+    self.cancellable = currentUserMemoViewModel.$currentUserMemo
+      .sink { [weak self] newMemo in
+      }
+  }
+  
+  // MARK: - Methods
+  
+  func upDateCurrentUserMemo() {
+    let newUserMemo: UserMemo = UserMemo()
+    self.currentUserMemoViewModel.upDate(userMemo: newUserMemo)
+  }
 }


### PR DESCRIPTION
## issue
close #38 
## やったこと
- トップ画面の右上に新規メモ作成のボタンを配置した。
- ボタン押下時にcurrentUserMemoを更新して、TopViewが再描画されるようにした。

## トップ画面UI
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-24 at 15 33 21" src="https://github.com/user-attachments/assets/a16ae940-ac2c-45e5-8fbe-46764dcb87be" />

## やっていないこと
- 再描画時のアニメーションの作成
## その他
サイドメニューのメモの表示件数が８件を超えてしまうバグを確認したので対処したい。
