### PR TITLE
サイドメニューとシステムアイコンの問題を修正した

### DIFF
--- a/Child/Child/View/Top/TopView.swift
+++ b/Child/Child/View/Top/TopView.swift
@@ -38,7 +38,10 @@ struct TopView: View {
                 }
               }) {
                 Image(systemName: "line.3.horizontal")
-                  .font(.system(size: geometry.size.height * iconSizeRatio , weight: .bold))
+                  .font(.system(
+                    size: max(geometry.size.height * iconSizeRatio, 1),
+                    weight: .bold
+                  ))
                   .foregroundStyle(Color.black)
                   .padding(.leading, geometry.size.width * iconSidePaddingRatio)
               }
@@ -50,7 +53,10 @@ struct TopView: View {
                 viewModel.upDateCurrentUserMemo()
               }) {
                 Image(systemName: "pencil.circle.fill")
-                  .font(.system(size: geometry.size.height * iconSizeRatio , weight: .bold))
+                  .font(.system(
+                    size: max(geometry.size.height * iconSizeRatio, 1),
+                    weight: .bold
+                  ))
                   .foregroundStyle(Color.black)
                   .padding(.trailing, geometry.size.width * iconSidePaddingRatio)
               }

--- a/Child/Child/ViewModel/Top/SideMenuViewModel.swift
+++ b/Child/Child/ViewModel/Top/SideMenuViewModel.swift
@@ -18,17 +18,21 @@ class SideMenuViewModel: ObservableObject {
   
   init() {
     self.realm = try! Realm()
-    // 最新の8件のみを取得
-    let allMemos = realm.objects(UserMemo.self).sorted(byKeyPath: "createdAt", ascending: false)
+    
+    let allMemos = realm.objects(UserMemo.self)
+      .sorted(byKeyPath: "createdAt", ascending: false)
 
     if allMemos.count > 8 {
-      // 8件以上ある場合は最新の8件のみ
-      let limitedMemos = Array(allMemos.prefix(8))
+      //すべてのメモから最新8件を取得
+      let limitedMemosArray = Array(allMemos.prefix(8))
+      //最新8件のidを取得
+      let ids = limitedMemosArray.map { $0.id }
+      //それらのidを使って、同じidのRealmオブジェクトを再取得
+      //取得する際に作成日時にでソートして、新しいメモが上に表示されるようにする
       self.sideMenuMemoLists = realm.objects(UserMemo.self)
-        .filter("SELF IN %@", limitedMemos)
+        .filter("id IN %@", ids)
         .sorted(byKeyPath: "createdAt", ascending: false)
     } else {
-      // 8件以下の場合はそのまま
       self.sideMenuMemoLists = allMemos
     }
   }


### PR DESCRIPTION
## issue
close #40 
## やったこと
- サイドメニューにメモが9件以上表示されてしまうバグを修正した
- ビルド時のシステムアイコンのエラーや警告を確認し、対処した

## 各問題の内容
- **サイドメニューにメモが9件以上表示されてしまうバグ**
問題の原因のコード

**SideMenuViewModel**
```
init() {
    self.realm = try! Realm()
    // 最新の8件のみを取得
    let allMemos = realm.objects(UserMemo.self).sorted(byKeyPath: "createdAt", ascending: false)

    if allMemos.count > 8 {
      // 8件以上ある場合は最新の8件のみ
      let limitedMemos = Array(allMemos.prefix(8))
      self.sideMenuMemoLists = realm.objects(UserMemo.self)
        .filter("SELF IN %@", limitedMemos)
        .sorted(byKeyPath: "createdAt", ascending: false)
    } else {
      // 8件以下の場合はそのまま
      self.sideMenuMemoLists = allMemos
    }
  }
```
` .filter("SELF IN %@", limitedMemos)`としているが、 `filter("SELF IN %@") `に `Results<UserMemo>` ではなく `ArraySlice<UserMemo>`(`Array(allMemos.prefix(8)`)の戻り値)という、Realm がサポートしていない型を渡していたことが原因でフィルターができていなかったことが原因だった。
そこで、limitedMemos の各idを取得し、それを使いフィルターすることにした。

- **ビルド時のシステムアイコンに関するエラーや警告**
以下のようなメッセージがビルド時にログに表示された
```
CoreUI: -[CUICatalog namedVectorGlyphWithName:scaleFactor:deviceIdiom:layoutDirection:glyphSize:glyphWeight:glyphPointSize:appearanceName:] 'line.3.horizontal' called with scaleFactor == 3.000000 glyphPointSize == 0.000000 at '/Library/Developer/CoreSimulator/Volumes/iOS_22A3351/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SFSymbols.framework/CoreGlyphs.bundle/Assets.car'
CoreUI: -[CUICatalog namedVectorGlyphWithName:scaleFactor:deviceIdiom:layoutDirection:glyphSize:glyphWeight:glyphPointSize:appearanceName:] 'line.3.horizontal' called with scaleFactor == 3.000000 glyphPointSize == 0.000000 at '/Library/Developer/CoreSimulator/Volumes/iOS_22A3351/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SFSymbols.framework/CoreGlyphs.bundle/Assets.car'
CoreUI: -[CUICatalog namedVectorGlyphWithName:scaleFactor:deviceIdiom:layoutDirection:glyphSize:glyphWeight:glyphPointSize:appearanceName:] 'line.3.horizontal' called with scaleFactor == 3.000000 glyphPointSize == 0.000000 at '/Library/Developer/CoreSimulator/Volumes/iOS_22A3351/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SFSymbols.framework/CoreGlyphs.bundle/Assets.car'
CoreUI: -[CUICatalog namedVectorGlyphWithName:scaleFactor:deviceIdiom:layoutDirection:glyphSize:glyphWeight:glyphPointSize:appearanceName:] 'line.3.horizontal' called with scaleFactor == 3.000000 glyphPointSize == 0.000000 at '/Library/Developer/CoreSimulator/Volumes/iOS_22A3351/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SFSymbols.framework/CoreGlyphs.bundle/Assets.car'
No symbol named 'line.3.horizontal' found in system symbol set
```
原因ははっきりとしなかったが、おそらく描画のタイミングでアイコンのサイズが0になってしまうことが関係しているように見えた。アイコンのサイズはGeometryReaderを使って、デバイスの画面サイズによって可変するようにしているが描画のタイミングでGeometryReaderで画面のサイズを取得できていない時にシステムがアイコンのサイズを計算しようとして、結果、一時的にアイコンのサイズ＝０となってしまい以上のメッセージが表示されてしまったというように見えた。
そこで、アイコンの最小サイズを１に設定したところ、上記のメッセージは表示されなくなった.


## その他
メモ編集中に新規作成メモボタンを押した時に、1回タップしても新しいメモにならず、２回目で新しいメモになるという現象が確認されたので対処したい。