### PR TITLE
テキストフィールド入力時の新規メモ作成ボタン押下時のバグの修正完了

### DIFF
--- a/Child/Child/ViewModel/Top/TitleViewModel.swift
+++ b/Child/Child/ViewModel/Top/TitleViewModel.swift
@@ -24,6 +24,15 @@ class TitleViewModel: ObservableObject {
     // currentUserMemo の変化を監視
     self.cancellable = currentUserMemoViewModel.$currentUserMemo
       .sink { [weak self] newMemo in
+        //テキストフィールドの入力内容確定後の新規メモ作成ボタン押下時のバグ回避のための処理
+        //参考　https://dev.classmethod.jp/articles/swiftui-japanese-input-textfield-clear-button-issue/?utm_source=chatgpt.com
+        
+        if newMemo.title.isEmpty && !self!.title.isEmpty {
+          let _ = self?.title.removeLast()
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            self?.title = ""
+          }
+        }
         self?.title = newMemo.title
       }
   }


### PR DESCRIPTION
## issue
close #42 
## やったこと
テキストフィールド入力時に新規メモ作成ボタンを押した時に、２回押さないと新規メモにならないバグを修正。
[参考記事](https://dev.classmethod.jp/articles/swiftui-japanese-input-textfield-clear-button-issue/?utm_source=chatgpt.com)
## やっていないこと
このバグを修正中にさらにいくつかのバグや検討したいことを確認したため対処していきたい
- キーボードを表示すると、UIが上に押し上げられる現象を確認。UIが崩れている。
→キーボード表示中に、GeometryReaderがキーボード以外の領域のサイズを取得していることが原因だと考えられる。
- サイドメニューのメモリストの中に空白のメモを確認。タイトルが空白の場合は「タイトル未設定」となるはず。
- キーボードを表示している時に、キーボード操作以外の操作をできるようにするか検討する。
→現在キーボードを表示中にサイドメニューを開いた場合、サイドメニューの真ん中より下がキーボードに隠れてしまう。なのでキーボードを閉じるボタンや設定ボタンが押すことができない状態になる。このあたりの仕様を検討したい。
