### PR TITLE
Feature/#48 create a process while the keyboard is displaying

### DIFF
--- a/Child/Child/View/Top/TopView.swift
+++ b/Child/Child/View/Top/TopView.swift
@@ -12,6 +12,7 @@ struct TopView: View {
   // MARK: Properties
   
   @StateObject private var viewModel: TopViewModel = TopViewModel()
+  @State private var isKeyboardVisible: Bool = false
   
   // iPhone16Proの画面のHeight874（CSSピクセル）を基準に算出
   private let titleHeightRatio: CGFloat = 0.11
@@ -84,11 +85,24 @@ struct TopView: View {
           }
           
           SideMenuView(isOpen: $viewModel.isSideMenuOpen)
+          
+          if isKeyboardVisible {
+            Color.black.opacity(0.001)
+              .ignoresSafeArea()
+              .onTapGesture {} // タップを吸収
+          }
         }
       }
     }
     .navigationBarHidden(true)
     .accentColor(.gray)
+    
+    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+      isKeyboardVisible = true
+    }
+    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+      isKeyboardVisible = false
+    }
   }
 }
 

--- a/Child/Child/View/Top/TopView.swift
+++ b/Child/Child/View/Top/TopView.swift
@@ -89,7 +89,15 @@ struct TopView: View {
           if isKeyboardVisible {
             Color.black.opacity(0.001)
               .ignoresSafeArea()
-              .onTapGesture {} // タップを吸収
+              .onTapGesture {
+                // 🔹 キーボードを閉じる
+                UIApplication.shared.sendAction(
+                  #selector(UIResponder.resignFirstResponder),
+                  to: nil,
+                  from: nil,
+                  for: nil
+                )
+              }
           }
         }
       }


### PR DESCRIPTION
## issue
close #48 
## やったこと
- キーボードが表示されているときはキーボード以外の領域に透明なViewを被せて、キーボード以外の領域を操作不能にした。
- 透明な領域をタップした時にキーボードが閉じるようにした。

## その他
