### PR TITLE
サイドメニューに表示されているメモを削除できるようにした

### DIFF
--- a/Child/Child/View/Top/SideMenu/SideMenuView.swift
+++ b/Child/Child/View/Top/SideMenu/SideMenuView.swift
@@ -63,6 +63,9 @@ struct SideMenuView: View {
                     handleMemoTap(item)
                   }
                 }
+                .onDelete { offsets in
+                  viewModel.deleteItems(at: offsets)
+                }
               }
               
               Section {

--- a/Child/Child/ViewModel/Top/SideMenuViewModel.swift
+++ b/Child/Child/ViewModel/Top/SideMenuViewModel.swift
@@ -70,5 +70,23 @@ class SideMenuViewModel: ObservableObject {
     guard let userMemo = item.userMemo else { return }
     CurrentUserMemoViewModel.shared.upDate(userMemo: userMemo)
   }
+  
+  func deleteItems(at offsets: IndexSet) {
+    let items = getDisplayItems()
+    
+    for index in offsets {
+      let item = items[index]
+      if let userMemo = item.userMemo {
+        do {
+          try realm.write {
+            realm.delete(userMemo)
+          }
+        } catch {
+          print("削除エラー: \(error.localizedDescription)")
+        }
+      }
+    }
+  }
+
 
 }

--- a/Child/Child/ViewModel/Top/SideMenuViewModel.swift
+++ b/Child/Child/ViewModel/Top/SideMenuViewModel.swift
@@ -12,54 +12,41 @@ import RealmSwift
 class SideMenuViewModel: ObservableObject {
   
   // MARK: - Properties
-  
   @Published var sideMenuMemoLists: Results<UserMemo>
   let realm: Realm
   
   init() {
     self.realm = try! Realm()
-    
+    self.sideMenuMemoLists = realm.objects(UserMemo.self)
+      .sorted(byKeyPath: "createdAt", ascending: false)
+    reloadSideMenuMemoLists()
+  }
+  
+  // MARK: - Methods
+  
+  /// 最新の最大8件を再取得する
+  private func reloadSideMenuMemoLists() {
     let allMemos = realm.objects(UserMemo.self)
       .sorted(byKeyPath: "createdAt", ascending: false)
-
+    
     if allMemos.count > 8 {
-      //すべてのメモから最新8件を取得
       let limitedMemosArray = Array(allMemos.prefix(8))
-      //最新8件のidを取得
       let ids = limitedMemosArray.map { $0.id }
-      //それらのidを使って、同じidのRealmオブジェクトを再取得
-      //取得する際に作成日時にでソートして、新しいメモが上に表示されるようにする
       self.sideMenuMemoLists = realm.objects(UserMemo.self)
         .filter("id IN %@", ids)
         .sorted(byKeyPath: "createdAt", ascending: false)
     } else {
       self.sideMenuMemoLists = allMemos
     }
+    // Published 更新を反映させる
+    objectWillChange.send()
   }
-  
-  // MARK: - Methods
-  
-//  func getTitlesFromSideMenuMemoLists() -> [String] {
-//    // 実際のメモからタイトルを取得し、配列に変換
-//    var titles = Array(sideMenuMemoLists.map { userMemo in
-//      return userMemo.title.isEmpty ? "タイトル未設定" : userMemo.title
-//    })
-//    
-//    // 8件に満たない場合は空文字で埋める
-//    while titles.count < 8 {
-//      titles.append("")
-//    }
-//    
-//    return titles
-//  }
   
   func getDisplayItems() -> [UserMemoListItem] {
     var items: [UserMemoListItem] = []
-    
     for userMemo in self.sideMenuMemoLists {
       items.append(UserMemoListItem(userMemo: userMemo))
     }
-    
     while items.count < 8 {
       items.append(UserMemoListItem(userMemo: nil))
     }
@@ -86,7 +73,7 @@ class SideMenuViewModel: ObservableObject {
         }
       }
     }
+    // 🔴 削除後に再取得して8件に揃える
+    reloadSideMenuMemoLists()
   }
-
-
 }


### PR DESCRIPTION
## issue
close #50 
## やったこと
- .onDelete を使用してサイドメニューに表示されているメモをスワイプで削除できるようにした。
## やっていないこと
- メモ一覧画面でのメモ削除機能の作成
- リストとその他のボタン等の要素の分離

