### PR TITLE
リストとその他の要素の分離完了

### DIFF
--- a/Child/Child/View/Top/SideMenu/SideMenuView.swift
+++ b/Child/Child/View/Top/SideMenu/SideMenuView.swift
@@ -15,8 +15,9 @@ struct SideMenuView: View {
   
   @Binding var isOpen: Bool
   
-  
   private let maxWidth = UIScreen.main.bounds.width
+  
+  let backgroundColor = Color(red: 0.95, green: 0.95, blue: 0.95)
   
   // Iphone16Pro(Height: 874px)を基準に各レートを算出
   // 例　memoRowsHeightRatio → 38 % 874 = 0.043478.....
@@ -26,114 +27,110 @@ struct SideMenuView: View {
   private let gearshapeIconLeadingPaddingRatio = 0.017
   private let xmarkIconHeightRatio: CGFloat = 0.040
   private let xmarkIconTrailingPaddingRatio = 0.017
+  private let moreTextTrailingPaddingRatio = 0.017
   private let moreSectionFotterHeightRatio: CGFloat = 0.068
   private let settingsSectionSpaceRatio: CGFloat = 0.0228
   
   // MARK: - Body
   
   var body: some View {
-    ZStack {
-        GeometryReader { geometry in
-          Color.black
-            .edgesIgnoringSafeArea(.all)
-            .opacity(isOpen ? 0.4 : 0)
-            .onTapGesture {
-              withAnimation(.linear(duration: 0.2)) {
-                isOpen.toggle()
-              }
+    ZStack() {
+      GeometryReader { geometry in
+        Color.black
+          .edgesIgnoringSafeArea(.all)
+          .opacity(isOpen ? 0.4 : 0)
+          .onTapGesture {
+            withAnimation(.linear(duration: 0.2)) {
+              isOpen.toggle()
             }
-          ZStack {
-            
-            let fullHeight = geometry.size.height + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom
-            
-            List() {
-              
-              Section {
-                ForEach(viewModel.getDisplayItems()) { item in
-                  HStack {
-                    Text(item.displayTitle)
-                      .frame(height: fullHeight * memoRowsHeightRatio)
-                      .lineLimit(1)
-                      .truncationMode(.tail)
-                    
-                    Spacer()
-                  }
-                  .contentShape(Rectangle())
-                  .onTapGesture {
-                    handleMemoTap(item)
-                  }
-                }
-                .onDelete { offsets in
-                  viewModel.deleteItems(at: offsets)
-                }
-              }
-              
-              Section {
-                NavigationLink(
-                    destination: MemoListView()
-                        .onAppear {
-                            // 画面遷移のアニメーション時間を考慮して遅延
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                isOpen = false
-                            }
-                        }
-                ) {
-                    HStack(spacing: 4) {
-                        Spacer()
-                        Text("more")
-                            .font(.system(size: fullHeight * moreTextHeightRatio))
-                    }
-                    .foregroundStyle(.gray)
-                }
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-              } footer: {
-                Spacer()
-                  .frame(height: fullHeight * moreSectionFotterHeightRatio)
-              }
-
-              
-              Section {
-                VStack(spacing: fullHeight * settingsSectionSpaceRatio) {
-                  Divider()
-                    .frame(height: 1.5)
-                    .background(Color.gray.opacity(0.4))
-                    .shadow(color: Color.black.opacity(0.4),
-                            radius: 4, x: 0, y: -2)
-                  
-                  HStack {
-                    Image(systemName: "gearshape")
-                      .font(.system(size: fullHeight * gearshapeIconHeightRatio))
-                      .foregroundStyle(.gray)
-                      .padding(.leading, fullHeight * gearshapeIconLeadingPaddingRatio)
-                    Spacer()
-                    
-                    Button(action: {
-                      withAnimation(.linear(duration: 0.2)) {
-                        isOpen.toggle()
-                      } }) {
-                        Image(systemName: "xmark")
-                          .font(.system(size: fullHeight * xmarkIconHeightRatio))
-                      }
-                      .buttonStyle(XmarkButtonColorStyle())
-                      .padding(.trailing, fullHeight * xmarkIconTrailingPaddingRatio)
-                  }
-                }
-                .listRowInsets(EdgeInsets())
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-              }
-            }
-            .scrollDisabled(true)
-            .listStyle(.grouped)
-            .frame(maxHeight: geometry.size.height)
           }
-          .padding(.trailing, maxWidth/4)
-          .offset(x: isOpen ? 0 : -maxWidth)
+        
+        VStack {
+          let fullHeight = geometry.size.height + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom
+          //　メモリスト
+          List() {
+            Section {
+              ForEach(viewModel.getDisplayItems()) { item in
+                HStack {
+                  Text(item.displayTitle)
+                    .frame(height: fullHeight * memoRowsHeightRatio)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                  Spacer()
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                  handleMemoTap(item)
+                }
+              }
+              .onDelete { offsets in
+                viewModel.deleteItems(at: offsets)
+              }
+            }
+          }
+          .frame(height: geometry.size.height * 0.7)
+          .scrollContentBackground(.hidden)
+          .scrollDisabled(true)
+          .listStyle(.grouped)
+          
+          // moreボタン
+          NavigationLink(
+            destination: MemoListView()
+              .onAppear {
+                // 画面遷移のアニメーション時間を考慮して遅延
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                  isOpen = false
+                }
+              }
+          ) {
+            HStack(spacing: 4) {
+              Spacer()
+              Text("more")
+                .font(.system(size: fullHeight * moreTextHeightRatio))
+            }
+            .foregroundStyle(.gray)
+            .padding(.top, 8)
+            .padding(.trailing,  fullHeight * moreTextTrailingPaddingRatio)
+          }
+          
+          Spacer()
+          //　閉じる、設定ボタン
+          VStack(spacing: fullHeight * settingsSectionSpaceRatio) {
+            Divider()
+              .frame(height: 1.5)
+              .background(Color.gray.opacity(0.4))
+              .shadow(color: Color.black.opacity(0.4),
+                      radius: 4, x: 0, y: -2)
+            
+            HStack {
+              Image(systemName: "gearshape")
+                .font(.system(size: fullHeight * gearshapeIconHeightRatio))
+                .foregroundStyle(.gray)
+                .padding(.leading, fullHeight * gearshapeIconLeadingPaddingRatio)
+              Spacer()
+              
+              Button(action: {
+                withAnimation(.linear(duration: 0.2)) {
+                  isOpen.toggle()
+                } }) {
+                  Image(systemName: "xmark")
+                    .font(.system(size: fullHeight * xmarkIconHeightRatio))
+                }
+                .buttonStyle(XmarkButtonColorStyle())
+                .padding(.trailing, fullHeight * xmarkIconTrailingPaddingRatio)
+            }
+          }
+          .padding(.bottom, 10)
         }
-      
+        .frame(height: geometry.size.height)
+        .background(backgroundColor)
+        .padding(.trailing, maxWidth/4)
+        .offset(x: isOpen ? 0 : -maxWidth)
+      }
     }
   }
+  
+  // MARK: - Methods
   
   private func handleMemoTap(_ item: UserMemoListItem) {
     if !item.isEmpty {


### PR DESCRIPTION
## issue
close #52 
## やったこと
サイドメニューのリストとその他ボタンなどの要素を分離して配置した。

## やっていないこと
- トップ画面にメモを表示している時に、そのメモを削除し、トップ画面に残っているその削除済みのメモを編集した時にアプリが落ちるバグを確認
→メモ削除時にそのメモのRealmデータも削除しており、編集時にすでに存在しないデータを参照したことによるクラッシュ。そもそもメモ削除時にトップ画面に削除したメモが表示されていることがまずいので対応する。

- メモが8件以下の時に8件以上連続でメモを作成した場合、一時的にサイドメニューに9件以上メモが表示されてしまうバグも確認。具体的なバグ再現方法は不明。
