### PR TITLE
トップ画面に表示されているメモを削除した場合のバグ修正

### DIFF
--- a/Child/Child/ViewModel/Top/SideMenuViewModel.swift
+++ b/Child/Child/ViewModel/Top/SideMenuViewModel.swift
@@ -17,6 +17,7 @@ class SideMenuViewModel: ObservableObject {
   
   init() {
     self.realm = try! Realm()
+      
     self.sideMenuMemoLists = realm.objects(UserMemo.self)
       .sorted(byKeyPath: "createdAt", ascending: false)
     reloadSideMenuMemoLists()
@@ -63,7 +64,15 @@ class SideMenuViewModel: ObservableObject {
     
     for index in offsets {
       let item = items[index]
+      
       if let userMemo = item.userMemo {
+        //削除するメモが現在表示中のメモだったら
+        if userMemo.id == CurrentUserMemoViewModel.shared.currentUserMemo.id {
+          //新しいメモをセットする
+          let newMemo = UserMemo()
+          CurrentUserMemoViewModel.shared.upDate(userMemo: newMemo)
+        }
+        
         do {
           try realm.write {
             realm.delete(userMemo)
@@ -73,7 +82,9 @@ class SideMenuViewModel: ObservableObject {
         }
       }
     }
-    // 🔴 削除後に再取得して8件に揃える
     reloadSideMenuMemoLists()
   }
+
 }
+
+


### PR DESCRIPTION
## issue
close #54 
## やったこと
- トップ画面に表示されているメモを削除した場合のバグ修正
→メモの削除時にトップ画面に表示するUserMemoを更新するようにした。
## やっていないこと
メモ一覧画面でも同様の処理を実装するので共通化する
