### PR TITLE
サイドメニューのから行表示の廃止完了

### DIFF
--- a/Child/Child/ViewModel/Top/SideMenuViewModel.swift
+++ b/Child/Child/ViewModel/Top/SideMenuViewModel.swift
@@ -54,9 +54,6 @@ class SideMenuViewModel: ObservableObject {
     for userMemo in self.sideMenuMemoLists {
       items.append(UserMemoListItem(userMemo: userMemo))
     }
-    while items.count < 8 {
-      items.append(UserMemoListItem(userMemo: nil))
-    }
     return items
   }
   


### PR DESCRIPTION
## issue
close #58 
## やったこと
- サイドメニューのメモの空行表示を廃止して、登録メモが8件以下の場合はその数のみ表示するようにした。
## 廃止後UI
<img width="319" height="668" alt="スクリーンショット 2025-08-26 13 50 19" src="https://github.com/user-attachments/assets/01c8ef78-55b5-434f-96da-828830c65894" />

## やっていないこと
メモが一件のない場合のプレスホルダーViewの作成

