### PR TITLE
メモリストのアイテムのカスタムViewを作成した

### DIFF
--- a/Child/Child/View/MemoList/MemoListView.swift
+++ b/Child/Child/View/MemoList/MemoListView.swift
@@ -14,9 +14,6 @@ struct MemoListView: View {
   @StateObject var viewModel: MemoListViewModel = MemoListViewModel()
   @Environment(\.dismiss) private var dismiss
   
-  private let memoRowsHeightRatio: CGFloat = 0.0434
-  
-  
   // MARK: - Body
   
   var body: some View {
@@ -27,15 +24,8 @@ struct MemoListView: View {
       List {
         Section {
           ForEach(viewModel.getDisplayItems()) { item in
-            HStack {
-              Text(item.displayTitle)
-                .frame(height: fullHeight * memoRowsHeightRatio)
-                .lineLimit(1)
-                .truncationMode(.tail)
-              
-              Spacer()
-            }
-            .contentShape(Rectangle())
+            
+            UserMemoListItemView(item: item)
             .onTapGesture {
               handleMemoTap(item)
             }

--- a/Child/Child/View/Other/UserMemoListItemView.swift
+++ b/Child/Child/View/Other/UserMemoListItemView.swift
@@ -1,0 +1,48 @@
+//
+//  UserMemoListItemView.swift
+//  Child
+//
+//  Created by 川島真之 on 2025/08/29.
+//
+
+import SwiftUI
+
+struct UserMemoListItemView: View {
+  
+  private let item: UserMemoListItem
+  
+  private let memoTitleFontSizeRatio: CGFloat = 0.0202
+  private let memoUpdatedDateFontSizeRatio: CGFloat = 0.0309
+  
+  init (item: UserMemoListItem) {
+    self.item = item
+  }
+  
+  var body: some View {
+    
+    let screenHeight = UIScreen.main.bounds.height
+    let screenWidth = UIScreen.main.bounds.width
+    
+    VStack {
+      HStack {
+        Text(item.displayTitle)
+          .font(.system(size: screenHeight * memoTitleFontSizeRatio))
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .padding(.leading, 6)
+        Spacer()
+      }
+      
+      HStack {
+        Text(item.displayUpdatedDate)
+          .font(.system(size: screenWidth * memoUpdatedDateFontSizeRatio))
+          .foregroundColor(Color.gray)
+          .padding(.leading, 6)
+        Spacer()
+      }
+      
+    }
+    .contentShape(Rectangle())
+  }
+}
+

--- a/Child/Child/View/Top/SideMenu/SideMenuView.swift
+++ b/Child/Child/View/Top/SideMenu/SideMenuView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct SideMenuView: View {
   
+  //memo fullHeight = 874, geometry.size.height = 778.0
+  //memoTitleFontSize = 17.7384, memoUpdateDateFontSize = 12.448
+  
   // MARK: - Properties
   
   @StateObject var viewModel: SideMenuViewModel = SideMenuViewModel()
@@ -17,7 +20,7 @@ struct SideMenuView: View {
   
   private let maxWidth = UIScreen.main.bounds.width
   
-  let backgroundColor = Color(red: 0.95, green: 0.95, blue: 0.95)
+  private let backgroundColor = Color(red: 0.95, green: 0.95, blue: 0.95)
   
   // Iphone16Pro(Height: 874px, Width: 402px)を基準に各レートを算出
   // 例　memoRowsHeightRatio → 38 % 874 = 0.043478.....
@@ -31,10 +34,7 @@ struct SideMenuView: View {
   private let moreSectionFotterHeightRatio: CGFloat = 0.068
   private let settingsSectionSpaceRatio: CGFloat = 0.0228
   private let placerHolderTextFontSizeRatio: CGFloat = 0.08
-  
-  private let memoTitleFontSizeRatio: CGFloat = 0.0228
-  private let memoUpdatedDateFontSizeRatio: CGFloat = 0.0160
-  
+
   // MARK: - Body
   
   var body: some View {
@@ -59,26 +59,8 @@ struct SideMenuView: View {
             List() {
               Section {
                 ForEach(viewModel.getDisplayItems()) { item in
-                  VStack {
-                    HStack {
-                      Text(item.displayTitle)
-                        .font(.system(size: geometry.size.height * memoTitleFontSizeRatio))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .padding(.leading, 6)
-                      Spacer()
-                    }
-                    
-                    HStack {
-                      Text(item.displayUpdatedDate)
-                        .font(.system(size: geometry.size.height * memoUpdatedDateFontSizeRatio))
-                        .foregroundColor(Color.gray)
-                        .padding(.leading, 6)
-                      Spacer()
-                    }
-                    
-                  }
-                  .contentShape(Rectangle())
+                  
+                  UserMemoListItemView(item: item)
                   .onTapGesture {
                     handleMemoTap(item)
                   }

--- a/Child/Child/ViewModel/MemoList/MemoListViewModel.swift
+++ b/Child/Child/ViewModel/MemoList/MemoListViewModel.swift
@@ -45,7 +45,6 @@ class MemoListViewModel: ObservableObject {
   func selectMemo(_ item: UserMemoListItem) {
     guard let userMemo = item.userMemo else { return }
     CurrentUserMemoViewModel.shared.upDate(userMemo: userMemo)
-    print(CurrentUserMemoViewModel.shared.currentUserMemo)
   }
 
 }

--- a/Child/Child/ViewModel/Top/SideMenuViewModel.swift
+++ b/Child/Child/ViewModel/Top/SideMenuViewModel.swift
@@ -86,7 +86,6 @@ class SideMenuViewModel: ObservableObject {
         }
       }
     }
-    reloadSideMenuMemoLists()
   }
   
   func hasAnyUserMemo() -> Bool {


### PR DESCRIPTION
## issue
close #64 
## やったこと
- メモリストに表示している各メモを表現するアイテムのViewをカスタムViewとして切り分けた。
- それをサイドメニューとメモ一覧画面に導入した。
## やっていないこと
- メモ一覧画面の削除機能の実装

