### PR TITLE
コンテンツViewの２行表示と微調整

### DIFF
--- a/Child/Child/View/Top/ContentView.swift
+++ b/Child/Child/View/Top/ContentView.swift
@@ -16,11 +16,13 @@ struct ContentView: View {
   
   var body: some View {
     GeometryReader { geometry in
-      TextField("", text: Binding(
-        get: { viewModel.textContent },
-        set: { viewModel.updateContent($0) }
-      ))
+      ScrollView(.vertical, showsIndicators: true) {
+        TextEditor(text: Binding(
+          get: { viewModel.textContent },
+          set: { viewModel.updateContent($0) }
+        ))
         .padding(.horizontal, geometry.size.width * TextEditorSidePaddingRatio)
+      }
     }
   }
 }

--- a/Child/Child/View/Top/TopView.swift
+++ b/Child/Child/View/Top/TopView.swift
@@ -15,7 +15,7 @@ struct TopView: View {
   @State private var isKeyboardVisible: Bool = false
   
   // iPhone16Proの画面のHeight874（CSSピクセル）を基準に算出
-  private let titleHeightRatio: CGFloat = 0.11
+  private let titleHeightRatio: CGFloat = 0.08
   private let contentHeightRatio: CGFloat = 0.58
   private let sideMenuIconBottomSpacerHeightRatio: CGFloat = 0.06
   private let contentViewBottomSpacerHeightRatio: CGFloat = 0.023


### PR DESCRIPTION
## issue
close #74 
## やったこと
- コンテンツViewのTextFieldをTextEditorに変更して、テキストを２行以上表示できるようにした。
- タイトルViewの高さを調整して、コンテンツViewとの間隔を調整した。
- コンテンツViewのテキストをスクロールで確認できるようにした。
