### PR TITLE
アプリ起動時に自動的にタイトルが選択された状態にされるようにした

### DIFF
--- a/Child/Child/View/Top/TitleView.swift
+++ b/Child/Child/View/Top/TitleView.swift
@@ -10,6 +10,7 @@ import RealmSwift
 
 struct TitleView: View {
   @StateObject private var viewModel = TitleViewModel()
+  @FocusState private var isTextFieldFocused: Bool
 
   var body: some View {
     GeometryReader { geometry in
@@ -21,6 +22,12 @@ struct TitleView: View {
         .lineLimit(1)
         .font(.system(size: geometry.size.width * 0.074))
         .padding(.horizontal, geometry.size.width * 0.024)
+        .focused($isTextFieldFocused)
+        .onAppear {
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            isTextFieldFocused = true
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## issue
close #80 
## やったこと
- アプリ起動時に自動的にタイトルが選択された状態にされるようにした。
## 今後について
ひとまず実装したがこの仕様を最終的に採用するかは検討する。ユーザーがメモを入力せずに、既存のメモを確認したいだけの場合余計な操作をさせることになるため。
