### PR TITLE
Viewのサイズ調整とテキストフィールドとテキストエディタのタップ検知範囲の拡大をした

### DIFF
--- a/Child/Child/View/Top/ContentView.swift
+++ b/Child/Child/View/Top/ContentView.swift
@@ -22,13 +22,23 @@ struct ContentView: View {
   var body: some View {
     GeometryReader { geometry in
       ScrollView(.vertical, showsIndicators: true) {
-        ZStack {
+        
+        ZStack(alignment: .topLeading) {
+          
+          Color.clear
+            .contentShape(Rectangle()) // タップ判定を全体に
+            .onTapGesture {
+              focusedField.wrappedValue = .content
+            }
+          
           TextEditor(text: Binding(
             get: { viewModel.textContent },
             set: { viewModel.updateContent($0) }
           ))
           .padding(.horizontal, geometry.size.width * TextEditorSidePaddingRatio)
+          .frame(width: geometry.size.width, height: geometry.size.height)
           .focused(focusedField, equals: .content)
+          
           HStack {
             Text("本文")
               .opacity(viewModel.textContent.isEmpty ? 0.3 : 0.0)
@@ -39,6 +49,7 @@ struct ContentView: View {
           }
           .padding(.horizontal, geometry.size.width * TextEditorSidePaddingRatio)
         }
+
       }
     }
   }

--- a/Child/Child/View/Top/TitleView.swift
+++ b/Child/Child/View/Top/TitleView.swift
@@ -23,19 +23,29 @@ struct TitleView: View {
   var body: some View {
     GeometryReader { geometry in
       ScrollView(.horizontal, showsIndicators: true) {
-        TextField("タイトル", text: Binding(
-          get: { viewModel.title },
-          set: { viewModel.updateTitle($0) }
-        ))
-        .lineLimit(1)
-        .font(.system(size: geometry.size.width * textFieldFontSizeRatio))
-        .padding(.horizontal, geometry.size.width * textFieldPaddingHorizontalRatio)
-        .focused(focusedField, equals: .title)
-        .onAppear {
-          if viewModel.isFirstLaunch {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        ZStack {
+          
+          Color.clear
+            .contentShape(Rectangle()) // タップ判定を全体に
+            .onTapGesture {
               focusedField.wrappedValue = .title
-              viewModel.isFirstLaunch = false
+            }
+          
+          TextField("タイトル", text: Binding(
+            get: { viewModel.title },
+            set: { viewModel.updateTitle($0) }
+          ))
+          .padding(.horizontal, geometry.size.width * textFieldPaddingHorizontalRatio)
+          .frame(width: geometry.size.width, height: geometry.size.height)
+          .lineLimit(1)
+          .font(.system(size: geometry.size.width * textFieldFontSizeRatio))
+          .focused(focusedField, equals: .title)
+          .onAppear {
+            if viewModel.isFirstLaunch {
+              DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                focusedField.wrappedValue = .title
+                viewModel.isFirstLaunch = false
+              }
             }
           }
         }

--- a/Child/Child/View/Top/TopView.swift
+++ b/Child/Child/View/Top/TopView.swift
@@ -76,6 +76,8 @@ struct TopView: View {
             }
             
             Spacer().frame(height: screenHeight * sideMenuIconBottomSpacerHeightRatio)
+            
+            
             VStack {
               TitleView(focusedField: $focusedField)
                 .frame(height: screenHeight * titleHeightRatio)


### PR DESCRIPTION
## issue
close #89 
## やったこと
- トップ画面の各Viewのサイズの微調整
- タイトルViewとコンテンツViewで、キーボードを表示させるためのタップを検知できる範囲をそれぞれのView全体に範囲を広げた。
## UI
<img width="327" height="685" alt="スクリーンショット 2025-09-07 15 35 43" src="https://github.com/user-attachments/assets/e9a69d50-0209-4631-afa3-ded30431185e" />

## やっていないこと
- 各ViewのUI的な微調整