### PR TITLE
サイドメニューのアイコンのカラー変更とダークモード非対応にした

### DIFF
--- a/Child/Child/Info.plist
+++ b/Child/Child/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>UIUserInterfaceStyle</key>
-	<string></string>
+	<string>Light</string>
 	<key>AdUnitIDs</key>
 	<dict>
 		<key>TopScreenBannerID</key>

--- a/Child/Child/Info.plist
+++ b/Child/Child/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string></string>
 	<key>AdUnitIDs</key>
 	<dict>
 		<key>TopScreenBannerID</key>

--- a/Child/Child/View/Top/SideMenu/SideMenuView.swift
+++ b/Child/Child/View/Top/SideMenu/SideMenuView.swift
@@ -130,7 +130,7 @@ struct SideMenuView: View {
               ) {
                 Image(systemName: "gearshape")
                   .font(.system(size: screenHeight * gearshapeIconHeightRatio))
-                  .foregroundStyle(Color.mainColor)
+                  .foregroundStyle(Color.gray)
                   .padding(.leading, screenHeight * gearshapeIconLeadingPaddingRatio)
               }
               Spacer()
@@ -141,7 +141,7 @@ struct SideMenuView: View {
                 } }) {
                   Image(systemName: "xmark")
                     .font(.system(size: screenHeight * xmarkIconHeightRatio))
-                    .foregroundStyle(Color.mainColor)
+                    .foregroundStyle(Color.gray)
                 }
                 .buttonStyle(XmarkButtonColorStyle())
                 .padding(.trailing, screenHeight * xmarkIconTrailingPaddingRatio)


### PR DESCRIPTION
## issue
close #118 
## やったこと
- サイドメニューの歯車とXアイコンのカラーをグレーにした
- ダークモード非対応にした

